### PR TITLE
fix: getting cppcheck version throws an exception

### DIFF
--- a/com.googlecode.cppcheclipse.core.tests/src/com/googlecode/cppcheclipse/core/command/TestVersion.java
+++ b/com.googlecode.cppcheclipse.core.tests/src/com/googlecode/cppcheclipse/core/command/TestVersion.java
@@ -1,8 +1,12 @@
 package com.googlecode.cppcheclipse.core.command;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
+import com.googlecode.cppcheclipse.core.command.Version.VersionType;
 
 public class TestVersion {
 
@@ -14,20 +18,23 @@ public class TestVersion {
 		assertEquals(1, version.getMajorVersion());
 		assertEquals(55, version.getMinorVersion());
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testInvalidVersion() {
 		new Version("1.2.3");
 	}
-	
+
 	@Test
 	public void testReleaseVersion() {
 		String versionString = "cppcheck 1.55";
 		Version version = new Version(versionString);
 		assertEquals(1, version.getMajorVersion());
 		assertEquals(55, version.getMinorVersion());
+		assertEquals(0, version.getRevision());
+		assertEquals(0, version.getPatch());
+		assertEquals(VersionType.OPEN_SOURCE, version.getType());
 	}
-	
+
 	@Test
 	public void testReleaseVersionWithRevision() {
 		String versionString = "cppcheck 1.2.3";
@@ -35,5 +42,294 @@ public class TestVersion {
 		assertEquals(1, version.getMajorVersion());
 		assertEquals(2, version.getMinorVersion());
 		assertEquals(3, version.getRevision());
+		assertEquals(0, version.getPatch());
+		assertEquals(VersionType.OPEN_SOURCE, version.getType());
 	}
+
+	@Test
+	public void testReleaseVersionWithPatch() {
+		String versionString = "cppcheck 1.2.3.4";
+		Version version = new Version(versionString);
+		assertEquals(1, version.getMajorVersion());
+		assertEquals(2, version.getMinorVersion());
+		assertEquals(3, version.getRevision());
+		assertEquals(4, version.getPatch());
+		assertEquals(VersionType.OPEN_SOURCE, version.getType());
+	}
+
+	@Test
+	public void testReleaseVersionPremium() {
+		String versionString = "cppcheck premium 1.2.3.4";
+		Version version = new Version(versionString);
+		assertEquals(1, version.getMajorVersion());
+		assertEquals(2, version.getMinorVersion());
+		assertEquals(3, version.getRevision());
+		assertEquals(4, version.getPatch());
+		assertEquals(VersionType.PREMIUM, version.getType());
+	}
+
+	@Test
+	public void testReleaseVersionPremiumSafetyCertified() {
+		String versionString = "cppcheck premium 1.2.3.4s";
+		Version version = new Version(versionString);
+		assertEquals(1, version.getMajorVersion());
+		assertEquals(2, version.getMinorVersion());
+		assertEquals(3, version.getRevision());
+		assertEquals(4, version.getPatch());
+		assertEquals(VersionType.PREMIUM_SAFETY_CERTIFIED, version.getType());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testIsGreaterThanCompareInvalidVersion() {
+		Version version1 = new Version("cppcheck 1.3");
+		Version version2 = new Version("cppcheck premium 2.3");
+		version2.isGreaterThan(version1);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testIsGreaterThanCompareInvalidVersion2() {
+		Version version1 = new Version("cppcheck 1.3");
+		Version version2 = new Version("cppcheck premium 2.3s");
+		version2.isGreaterThan(version1);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testIsGreaterThanCompareInvalidVersion3() {
+		Version version1 = new Version("cppcheck premium 1.3");
+		Version version2 = new Version("cppcheck premium 2.3s");
+		version2.isGreaterThan(version1);
+	}
+
+	@Test
+	public void testIsGreaterThanWithDifferentMajorVersions() {
+		Version version1 = new Version("cppcheck 1.3");
+		Version version2 = new Version("cppcheck 2.3");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumWithDifferentMajorVersions() {
+		Version version1 = new Version("cppcheck premium 1.3");
+		Version version2 = new Version("cppcheck premium 2.3");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumSafetyCertifiedWithDifferentMajorVersions() {
+		Version version1 = new Version("cppcheck premium 1.3s");
+		Version version2 = new Version("cppcheck premium 2.3s");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithSameMajorAndMinorVersions() {
+		Version version1 = new Version("cppcheck 1.2");
+		Version version2 = new Version("cppcheck 1.2");
+		assertFalse(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumWithSameMajorAndMinorVersions() {
+		Version version1 = new Version("cppcheck premium 1.2");
+		Version version2 = new Version("cppcheck premium 1.2");
+		assertFalse(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumSafetyCerifiedWithSameMajorAndMinorVersions() {
+		Version version1 = new Version("cppcheck premium 1.2s");
+		Version version2 = new Version("cppcheck premium 1.2s");
+		assertFalse(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanDifferentMinorVersions() {
+		Version version1 = new Version("cppcheck 1.2");
+		Version version2 = new Version("cppcheck 1.3");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumDifferentMinorVersions() {
+		Version version1 = new Version("cppcheck premium 1.2");
+		Version version2 = new Version("cppcheck premium 1.3");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumSafetyCertifiedDifferentMinorVersions() {
+		Version version1 = new Version("cppcheck premium 1.2s");
+		Version version2 = new Version("cppcheck premium 1.3s");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithDifferentMajorVersions2() {
+		Version version1 = new Version("cppcheck 1.2.3");
+		Version version2 = new Version("cppcheck 2.0.0");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumWithDifferentMajorVersions2() {
+		Version version1 = new Version("cppcheck premium 1.2.3");
+		Version version2 = new Version("cppcheck premium 2.0.0");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiuSafetyCertifiedmWithDifferentMajorVersions2() {
+		Version version1 = new Version("cppcheck premium 1.2.3s");
+		Version version2 = new Version("cppcheck premium 2.0.0s");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanDifferentMinorVersions2() {
+		Version version1 = new Version("cppcheck 1.2.6");
+		Version version2 = new Version("cppcheck 1.3.0");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumDifferentMinorVersions2() {
+		Version version1 = new Version("cppcheck premium 1.2.6");
+		Version version2 = new Version("cppcheck premium 1.3.0");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumSafetyCertifiedDifferentMinorVersions2() {
+		Version version1 = new Version("cppcheck premium 1.2.6s");
+		Version version2 = new Version("cppcheck premium 1.3.0s");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithDiffrentRevisionVersions() {
+		Version version1 = new Version("cppcheck 1.2.3");
+		Version version2 = new Version("cppcheck 1.2.4");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumWithDiffrentRevisionVersions() {
+		Version version1 = new Version("cppcheck premium 1.2.3");
+		Version version2 = new Version("cppcheck premium 1.2.4");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumSafetyCertifiedWithDiffrentRevisionVersions() {
+		Version version1 = new Version("cppcheck premium 1.2.3s");
+		Version version2 = new Version("cppcheck premium 1.2.4s");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithSameVersions() {
+		Version version1 = new Version("cppcheck 1.2.3");
+		Version version2 = new Version("cppcheck 1.2.3");
+		assertFalse(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithDiffrentRevisionVersions2() {
+		Version version1 = new Version("cppcheck 1.2.3.5");
+		Version version2 = new Version("cppcheck 1.2.4.5");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithDifferentPatchVersions() {
+		Version version1 = new Version("cppcheck 1.2.3.4");
+		Version version2 = new Version("cppcheck 1.2.3.5");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanWithDefaultRevisionAndPatch() {
+		Version version1 = new Version("cppcheck 1.2");
+		Version version2 = new Version("cppcheck 1.2.1");
+		Version version3 = new Version("cppcheck 1.2.0");
+		Version version4 = new Version("cppcheck 1.2.0.1");
+		assertTrue(version2.isGreaterThan(version1));
+		assertTrue(version4.isGreaterThan(version1));
+		assertFalse(version3.isGreaterThan(version1));
+		assertTrue(version4.isGreaterThan(version3));
+	}
+
+	@Test
+	public void testIsGreaterThanWithSamePatchVersions() {
+		Version version1 = new Version("cppcheck 1.2.3.4");
+		Version version2 = new Version("cppcheck 1.2.3.4");
+		assertFalse(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumVersions() {
+		Version version1 = new Version("cppcheck premium 1.2.3.4");
+		Version version2 = new Version("cppcheck premium 1.2.3.5");
+		Version version3 = new Version("cppcheck premium 1.2.3.5");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+		assertFalse(version2.isGreaterThan(version3));
+		assertFalse(version3.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testIsGreaterThanPremiumSafetyCerifiedVersions() {
+		Version version1 = new Version("cppcheck premium 1.2.3.4s");
+		Version version2 = new Version("cppcheck premium 1.2.3.5s");
+		Version version3 = new Version("cppcheck premium 1.2.3.5s");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+		assertFalse(version2.isGreaterThan(version3));
+		assertFalse(version3.isGreaterThan(version2));
+	}
+
+	@Test
+	public void testCompatibility() {
+		Version version1 = new Version("cppcheck 1.56");
+		Version version2 = new Version("cppcheck 1.56.0");
+		Version version3 = new Version("cppcheck 1.56.0.0");
+		assertTrue(version1.isCompatible());
+		assertTrue(version2.isCompatible());
+		assertTrue(version3.isCompatible());
+		version1 = new Version("cppcheck premium 1.56");
+		version2 = new Version("cppcheck premium 1.56.0");
+		version3 = new Version("cppcheck premium 1.56.0.0");
+		assertTrue(version1.isCompatible());
+		assertTrue(version2.isCompatible());
+		assertTrue(version3.isCompatible());
+		version1 = new Version("cppcheck premium 1.56s");
+		version2 = new Version("cppcheck premium 1.56.0s");
+		version3 = new Version("cppcheck premium 1.56.0.0s");
+		assertTrue(version1.isCompatible());
+		assertTrue(version2.isCompatible());
+		assertTrue(version3.isCompatible());
+	}
+
 }

--- a/com.googlecode.cppcheclipse.core.tests/src/com/googlecode/cppcheclipse/core/command/TestVersion.java
+++ b/com.googlecode.cppcheclipse.core.tests/src/com/googlecode/cppcheclipse/core/command/TestVersion.java
@@ -205,6 +205,14 @@ public class TestVersion {
 	}
 
 	@Test
+	public void testIsGreaterThanDifferentMinorVersions3() {
+		Version version1 = new Version("cppcheck 24.4.0");
+		Version version2 = new Version("cppcheck 24.10.1");
+		assertTrue(version2.isGreaterThan(version1));
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
 	public void testIsGreaterThanPremiumDifferentMinorVersions2() {
 		Version version1 = new Version("cppcheck premium 1.2.6");
 		Version version2 = new Version("cppcheck premium 1.3.0");

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/UpdateCheckCommand.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/UpdateCheckCommand.java
@@ -15,15 +15,17 @@ import com.googlecode.cppcheclipse.core.utils.IHttpClientService;
 
 public class UpdateCheckCommand {
 
-	private static final String UPDATE_URL = "https://cppcheck.sourceforge.net/version.txt";
+	private static final String UPDATE_URL_OPEN_SOURCE = "https://cppcheck.sourceforge.net/version.txt";
+	private static final String UPDATE_URL_PREMIUM = "https://files.cppchecksolutions.com/premium-version.txt";
+	private static final String UPDATE_URL_PREMIUM_SAFETY_CERTIFIED = "https://files.cppchecksolutions.com/premium-s-version.txt";
 
 	public UpdateCheckCommand() {
 
 	}
 
-	private Version getNewVersion() throws IOException, URISyntaxException {
+	private Version getNewVersion(String url) throws IOException, URISyntaxException {
 		IHttpClientService client = CppcheclipsePlugin.getHttpClientService();
-		InputStream is = client.executeGetRequest(new URL(UPDATE_URL));
+		InputStream is = client.executeGetRequest(new URL(url));
 		BufferedReader rd = new BufferedReader(new InputStreamReader(is));
 		String line = rd.readLine();
 		rd.close();
@@ -47,8 +49,19 @@ public class UpdateCheckCommand {
 	 * @throws URISyntaxException 
 	 */
 	public Version run(IProgressMonitor monitor, IConsole console, String binaryPath) throws IOException, InterruptedException, ProcessExecutionException, URISyntaxException {
-		Version newVersion = getNewVersion();
+		String updateUrl = UPDATE_URL_OPEN_SOURCE;
 		Version currentVersion = getCurrentVersion(monitor, console, binaryPath);
+		switch (currentVersion.getType()) {
+			case PREMIUM:
+				updateUrl = UPDATE_URL_PREMIUM;
+				break;
+			case PREMIUM_SAFETY_CERTIFIED:
+				updateUrl = UPDATE_URL_PREMIUM_SAFETY_CERTIFIED;
+				break;
+			default:
+				break;
+		}
+		Version newVersion = getNewVersion(updateUrl);
 		if (newVersion.isGreaterThan(currentVersion))
 			return newVersion;
 		return null;

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/UpdateCheckCommand.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/UpdateCheckCommand.java
@@ -15,7 +15,7 @@ import com.googlecode.cppcheclipse.core.utils.IHttpClientService;
 
 public class UpdateCheckCommand {
 
-	private static final String UPDATE_URL = "http://cppcheck.sourceforge.net/version.txt";
+	private static final String UPDATE_URL = "https://cppcheck.sourceforge.net/version.txt";
 
 	public UpdateCheckCommand() {
 

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/Version.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/Version.java
@@ -33,7 +33,7 @@ public class Version {
 	}
 
 	/** version string must have the format
-	 * "cppcheck <majorVersion>.<minorVersion>[.<revision>]"
+	 * "cppcheck [premium] <majorVersion>.<minorVersion>[.<revision>][.patch][s]"
 	 *
 	 * @param version
 	 */
@@ -101,14 +101,15 @@ public class Version {
 		if (version.versionType != VersionType.ANY && versionType != version.versionType) {
 			throw new IllegalArgumentException("Cannot compare versions of different types");
 		}
-		if (majorVersion > version.majorVersion)
-			return true;
-		if (majorVersion == version.majorVersion && minorVersion > version.minorVersion)
-			return true;
-		if (majorVersion == version.majorVersion && minorVersion == version.minorVersion && revision > version.revision)
-			return true;
-		return majorVersion == version.majorVersion && minorVersion == version.minorVersion && revision == version.revision && patch > version.patch;
+		if (majorVersion != version.majorVersion)
+			return majorVersion > version.majorVersion;
+		if (minorVersion != version.minorVersion)
+			return minorVersion > version.minorVersion;
+		if (revision != version.revision)
+			return revision > version.revision;
+		return patch > version.patch;
 	}
+
 
 	public boolean isGreaterOrEqual(Version version) {
 		return isGreaterThan(version) || equals(version);

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/Version.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/Version.java
@@ -5,57 +5,72 @@ import java.util.StringTokenizer;
 
 public class Version {
 
+	public enum VersionType {
+		OPEN_SOURCE,
+		PREMIUM,
+		PREMIUM_SAFETY_CERTIFIED,
+		ANY
+	}
+
 	private static final String VERSION_PREFIX = "cppcheck";
+	private static final String VERSION_PREMIUM = "premium";
+	private static final String SAFETY_CERTIFIED_MARK = "s";
 	private static final String DELIMITER = ".";
 	private final int majorVersion;
 	private final int minorVersion;
 	private final int revision;
-	
-	public static final Version MIN_VERSION = new Version (1, 56, 0);
-	
-	private Version(int majorVersion, int minorVersion, int revision) {
+	private final int patch;
+	private final VersionType versionType;
+
+	public static final Version MIN_VERSION = new Version (1, 56, 0, 0, VersionType.ANY);
+
+	private Version(int majorVersion, int minorVersion, int revision, int patch, VersionType versionType) {
 		this.majorVersion = majorVersion;
 		this.minorVersion = minorVersion;
 		this.revision = revision;
-	}	
-	
-	/** version string must have the format 
+		this.patch = patch;
+		this.versionType = versionType;
+	}
+
+	/** version string must have the format
 	 * "cppcheck <majorVersion>.<minorVersion>[.<revision>]"
-	 * 
+	 *
 	 * @param version
 	 */
 	public Version(String version) {
 		version = version.toLowerCase();
-		
+
 		if (!version.startsWith(VERSION_PREFIX)) {
 			throw new IllegalArgumentException("Version must start with " + VERSION_PREFIX + ", but is " + version);
 		}
-		
-		version = version.substring(VERSION_PREFIX.length());
-		version = version.trim();
-		
+
+		version = version.substring(VERSION_PREFIX.length()).trim();
+
+		if (version.contains(VERSION_PREMIUM) && version.endsWith(SAFETY_CERTIFIED_MARK)) {
+			versionType = VersionType.PREMIUM_SAFETY_CERTIFIED;
+			version = version.substring(VERSION_PREMIUM.length()).trim();
+		} else if (version.contains(VERSION_PREMIUM)) {
+			versionType = VersionType.PREMIUM;
+			version = version.substring(VERSION_PREMIUM.length()).trim();
+		} else {
+			versionType = VersionType.OPEN_SOURCE;
+		}
+
 		// extract the version with the delimiter from the string
 		version = version.replaceAll("[^0-9" + DELIMITER + "]","");
-		
+
 		try {
 			StringTokenizer tokenizer = new StringTokenizer(version, DELIMITER);
 			String versionPart = tokenizer.nextToken();
 			majorVersion = Integer.parseInt(versionPart);
 			versionPart = tokenizer.nextToken();
 			minorVersion = Integer.parseInt(versionPart);
-			
-			if (tokenizer.hasMoreTokens()) {
-				versionPart = tokenizer.nextToken();
-				revision = Integer.parseInt(versionPart);
-			} else {
-				revision = 0;
-			}
+			revision = tokenizer.hasMoreTokens() ? Integer.parseInt(tokenizer.nextToken()) : 0;
+			patch = tokenizer.hasMoreTokens() ? Integer.parseInt(tokenizer.nextToken()) : 0;
 		} catch (NoSuchElementException e) {
 			throw new IllegalArgumentException("Version must consist of at least two integers, separated by " + DELIMITER);
 		}
 	}
-
-
 
 	public int getMajorVersion() {
 		return majorVersion;
@@ -68,35 +83,35 @@ public class Version {
 	public int getRevision() {
 		return revision;
 	}
-	
+
+	public int getPatch() {
+		return patch;
+	}
+
+	public VersionType  getType() {
+		return versionType;
+	}
+
 	/**
-	 * 
+	 *
 	 * @param version
 	 * @return true if the given version is greater than the current version
 	 */
 	public boolean isGreaterThan(Version version) {
+		if (version.versionType != VersionType.ANY && versionType != version.versionType) {
+			throw new IllegalArgumentException("Cannot compare versions of different types");
+		}
 		if (majorVersion > version.majorVersion)
 			return true;
-		else if (majorVersion == version.majorVersion) {
-			if (minorVersion > version.minorVersion)
-				return true;
-			else if (minorVersion == version.minorVersion) {
-				if (revision > version.revision)
-					return true;
-			}
-		}
-		return false;
+		if (majorVersion == version.majorVersion && minorVersion > version.minorVersion)
+			return true;
+		if (majorVersion == version.majorVersion && minorVersion == version.minorVersion && revision > version.revision)
+			return true;
+		return majorVersion == version.majorVersion && minorVersion == version.minorVersion && revision == version.revision && patch > version.patch;
 	}
-	
+
 	public boolean isGreaterOrEqual(Version version) {
-		boolean result = isGreaterThan(version);
-		if (!result) {
-			// check for equality
-			if (equals(version)) {
-				return true;
-			}
-		}
-		return result;
+		return isGreaterThan(version) || equals(version);
 	}
 
 	/**
@@ -111,10 +126,10 @@ public class Version {
 	@Override
 	public String toString() {
 		StringBuffer version = new StringBuffer();
+		version.append(versionType.toString().toLowerCase()).append(" ");
 		version.append(majorVersion).append(".").append(minorVersion);
-		if (revision != 0) {
-			version.append(".").append(revision);
-		}
+		version.append(".").append(revision);
+		version.append(".").append(patch);
 		return version.toString();
 	}
 
@@ -125,6 +140,7 @@ public class Version {
 		result = prime * result + majorVersion;
 		result = prime * result + minorVersion;
 		result = prime * result + revision;
+		result = prime * result + patch;
 		return result;
 	}
 
@@ -142,6 +158,8 @@ public class Version {
 		if (minorVersion != other.minorVersion)
 			return false;
 		if (revision != other.revision)
+			return false;
+		if (patch != other.patch)
 			return false;
 		return true;
 	}


### PR DESCRIPTION
The http endpoint is not valid anymore.
This PR also adds premium versions parsing and queries different urls for updates, based on cppcheck version
reported.
More, the redirect HTTP 301 return code wasn't handled at all, hence the update checker was failing constantly.