### PR TITLE
feat: add new premium checks

### DIFF
--- a/com.googlecode.cppcheclipse.core.tests/src/com/googlecode/cppcheclipse/core/command/TestVersion.java
+++ b/com.googlecode.cppcheclipse.core.tests/src/com/googlecode/cppcheclipse/core/command/TestVersion.java
@@ -340,4 +340,26 @@ public class TestVersion {
 		assertTrue(version3.isCompatible());
 	}
 
+	@Test
+	public void testPremium() {
+		Version version1 = new Version("cppcheck 1.56");
+		Version version2 = new Version("cppcheck 1.56.0");
+		Version version3 = new Version("cppcheck 1.56.0.0");
+		assertFalse(version1.isPremium());
+		assertFalse(version2.isPremium());
+		assertFalse(version3.isPremium());
+		version1 = new Version("cppcheck premium 1.56");
+		version2 = new Version("cppcheck premium 1.56.0");
+		version3 = new Version("cppcheck premium 1.56.0.0");
+		assertTrue(version1.isPremium());
+		assertTrue(version2.isPremium());
+		assertTrue(version3.isPremium());
+		version1 = new Version("cppcheck premium 1.56s");
+		version2 = new Version("cppcheck premium 1.56.0s");
+		version3 = new Version("cppcheck premium 1.56.0.0s");
+		assertTrue(version1.isPremium());
+		assertTrue(version2.isPremium());
+		assertTrue(version3.isPremium());
+	}
+
 }

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/IPreferenceConstants.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/IPreferenceConstants.java
@@ -4,6 +4,7 @@ package com.googlecode.cppcheclipse.core;
  * Constant definitions for plug-in preferences
  */
 public interface IPreferenceConstants {
+	public static final String P_PREMIUM = "premium";
 	public static final String P_RUN_ON_BUILD = "runOnBuild";
 	public static final String P_PROBLEMS = "problems";
 	public static final String P_USE_PARENT_SUFFIX = "_useParentScope";
@@ -18,6 +19,14 @@ public interface IPreferenceConstants {
 	public static final String P_CHECK_INCONCLUSIVE = "checkInconclusive";
 	public static final String P_CHECK_FORCE = "checkForce";
 	public static final String P_CHECK_DEBUG = "checkDebug";
+	public static final String P_PREMIUM_BUG_HUNTING = "bughunting";
+	public static final String P_PREMIUM_MISRA_C_12 = "misrac12";
+	public static final String P_PREMIUM_MISRA_C_23 = "misrac23";
+	public static final String P_PREMIUM_MISRA_CPP_08 = "misracpp08";
+	public static final String P_PREMIUM_MISRA_CPP_23 = "misracpp23";
+	public static final String P_PREMIUM_CERT_C = "certc";
+	public static final String P_PREMIUM_CERT_CPP = "certcpp";
+	public static final String P_PREMIUM_AUTOSAR = "autosar";
 	public static final String P_USE_INLINE_SUPPRESSIONS = "useInlineSuppressions";
 	public static final String P_CHECK_UNUSED_FUNCTIONS = "checkUnusedFunctions";
 	public static final String P_FOLLOW_SYSTEM_INCLUDES = "followSystemIncludes";

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/CppcheckCommand.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/CppcheckCommand.java
@@ -55,8 +55,38 @@ public class CppcheckCommand extends AbstractCppcheckCommand {
 	private final static Pattern FILE_PATTERN = Pattern
 			.compile("^Checking (.*)...");
 
+	private static final String CPPCHECK_PROJ_STRING = ".cppcheck";
+
 	private final Collection<String> arguments;
 	private String advancedArguments;
+
+
+	private void addPremiumChecks(IPreferenceStore settingsStore) {
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_BUG_HUNTING)) {
+			arguments.add("--premium=bughunting");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_MISRA_C_12)) {
+			arguments.add("--premium=misra-c-2012");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_MISRA_C_23)) {
+			arguments.add("--premium=misra-c-2023");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_MISRA_CPP_08)) {
+			arguments.add("--premium=misra-c++-2008");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_MISRA_CPP_23)) {
+			arguments.add("--premium=misra-c++-2023");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_CERT_C)) {
+			arguments.add("--premium=cert-c-2016");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_CERT_CPP)) {
+			arguments.add("--premium=cert-c++-2016");
+		}
+		if (settingsStore.getBoolean(IPreferenceConstants.P_PREMIUM_AUTOSAR)) {
+			arguments.add("--premium=autosar");
+		}
+	}
 
 	/**
 	 * For testing purposes either use interfaces or simple types as parameters.
@@ -130,6 +160,10 @@ public class CppcheckCommand extends AbstractCppcheckCommand {
 			arguments.add("--file-filter=-");
 		} else {
 			arguments.add("--file-list=-");
+		}
+
+		if (projectFile.isEmpty() || !projectFile.endsWith(CPPCHECK_PROJ_STRING)) {
+			addPremiumChecks(settingsStore);
 		}
 
 		if (settingsStore.getBoolean(IPreferenceConstants.P_CHECK_VERBOSE)) {

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/Version.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/command/Version.java
@@ -124,6 +124,14 @@ public class Version {
 	}
 
 
+	/**
+	 * @return true if the version is a premium version
+	 */
+	public boolean isPremium() {
+		return getType() == VersionType.PREMIUM || getType() == VersionType.PREMIUM_SAFETY_CERTIFIED;
+	}
+
+
 	@Override
 	public String toString() {
 		StringBuffer version = new StringBuffer();

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/Messages.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/Messages.java
@@ -100,11 +100,21 @@ public class Messages extends NLS {
 	public static String SettingsPreferencePage_Debug;
 	public static String SettingsPreferencePage_ChecksLabel;
 	public static String SettingsPreferencePage_InlineSuppressions;
-	
+
+	public static String SettingsPreferencePage_PremiumBugHunting;
+	public static String SettingsPreferencePage_PremiumMisraC2012;
+	public static String SettingsPreferencePage_PremiumMisraC2023;
+	public static String SettingsPreferencePage_PremiumMisraCpp2008;
+	public static String SettingsPreferencePage_PremiumMisraCpp2023;
+	public static String SettingsPreferencePage_PremiumCertC;
+	public static String SettingsPreferencePage_PremiumCertCpp;
+	public static String SettingsPreferencePage_PremiumAutosar;
+	public static String SettingsPreferencePage_PremiumLabel;
+
 	public static String SymbolsPropertyPage_Description;
 
 	public static String SettingsPreferencePage_Inconclusive;
-	
+
 	public static String SettingsPreferencePage_TargetPlatform;
 
 	public static String SettingsPreferencePage_LanguageStandard_Posix;
@@ -112,7 +122,7 @@ public class Messages extends NLS {
 	public static String SettingsPreferencePage_LanguageStandard_C99;
 
 	public static String SettingsPreferencePage_LanguageStandardsLabel;
-	
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/messages.properties
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/messages.properties
@@ -38,6 +38,15 @@ SettingsPreferencePage_CheckPortability=Check for portability issues (portabilit
 SettingsPreferencePage_CheckInformation=Informative checks (information)
 SettingsPreferencePage_CheckMissingInclude=Check for missing includes (missingInclude)
 SettingsPreferencePage_ChecksLabel=Checks (--enable=<check>)
+SettingsPreferencePage_PremiumBugHunting=Bug Hunting
+SettingsPreferencePage_PremiumMisraC2012=Misra C 2012
+SettingsPreferencePage_PremiumMisraC2023=Misra C 2023
+SettingsPreferencePage_PremiumMisraCpp2008=Misra C++ 2008
+SettingsPreferencePage_PremiumMisraCpp2023=Misra C++ 2023
+SettingsPreferencePage_PremiumCertC=Cert C 2016
+SettingsPreferencePage_PremiumCertCpp=Cert C++ 2016
+SettingsPreferencePage_PremiumAutosar=Autosar
+SettingsPreferencePage_PremiumLabel=Premium (--premium=<option>)
 SettingsPreferencePage_Description=General settings of cppcheck.
 SettingsPreferencePage_FollowUserIncludes=Follow user-defined includes (taken from CDT settings)
 SettingsPreferencePage_FollowSystemIncludes=Follow system-defined includes (taken from CDT settings)

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -14,6 +14,7 @@ import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.StringButtonFieldEditor;
 import org.eclipse.debug.ui.StringVariableSelectionDialog;
 import org.eclipse.jface.preference.IPreferenceNode;
+import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.jface.preference.PreferenceManager;
 import org.eclipse.jface.preference.RadioGroupFieldEditor;
@@ -128,6 +129,10 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 						Version version = versionCommand
 								.run(new NullProgressMonitor());
 						currentVersion = version.toString();
+						IPersistentPreferenceStore store = CppcheclipsePlugin.getConfigurationPreferenceStore();
+						boolean isPremium = store.getBoolean(IPreferenceConstants.P_PREMIUM);
+						store.setValue(IPreferenceConstants.P_PREMIUM, version.isPremium());
+						store.save();
 						// check for minimal required version
 						if (!version.isCompatible()) {
 							showErrorMessage(Messages

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/ExclusiveBooleanFieldEditor.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/ExclusiveBooleanFieldEditor.java
@@ -1,0 +1,57 @@
+package com.googlecode.cppcheclipse.ui.preferences;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.swt.widgets.Composite;
+
+public class ExclusiveBooleanFieldEditor extends BooleanFieldEditor {
+
+	private BooleanFieldEditor dependencyFieldEditor;
+	private Composite parent;
+
+	public ExclusiveBooleanFieldEditor(String name, String label, Composite parent) {
+		super(name, label, parent);
+		this.parent = parent;
+	}
+
+	public ExclusiveBooleanFieldEditor(String name, String labelText, int style, Composite parent) {
+		super(name, labelText, style, parent);
+		this.parent = parent;
+	}
+
+	public ExclusiveBooleanFieldEditor(BooleanFieldEditor dependencyFieldEditor, String name, String label,
+			Composite parent) {
+		super(name, label, parent);
+		this.dependencyFieldEditor = dependencyFieldEditor;
+		this.parent = parent;
+	}
+
+	public ExclusiveBooleanFieldEditor(BooleanFieldEditor dependencyFieldEditor, String name, String labelText,
+			int style, Composite parent) {
+		super(name, labelText, style, parent);
+		this.dependencyFieldEditor = dependencyFieldEditor;
+		this.parent = parent;
+	}
+
+	public void addDependent(BooleanFieldEditor dependencyFieldEditor, Composite parent) {
+		this.dependencyFieldEditor = dependencyFieldEditor;
+		this.parent = parent;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled, Composite parent) {
+		if (enabled) {
+			if (dependencyFieldEditor != null) {
+				enabled = !dependencyFieldEditor.getBooleanValue();
+			}
+		}
+		super.setEnabled(enabled, parent);
+	}
+
+    @Override
+    protected void valueChanged(boolean oldValue, boolean newValue) {
+		super.valueChanged(oldValue, newValue);
+		if (dependencyFieldEditor != null) {
+			dependencyFieldEditor.setEnabled(!newValue, parent);
+		}
+	}
+}


### PR DESCRIPTION
This commit adds a group box "Premium checks". 
It is only enabled if Cppcheck Premium is used and project file is either omitted or is not "*.cppcheck" one.
The following premium options are supported:
 * Bug hunting
 * Misra C 2012
 * Misra C 2023
 * Misra C++ 2008
 * Misra C++ 2023
 * Cert C
 * Cert C++
 * Autosar

It's not possible to select both Misra C 2012 and Misra C 2023.
It's not possible to select both Misra C++ 2008 and Misra C++ 2023.
