### PR TITLE
fix # 11/ Read include paths from both C and C++ language settings

### DIFF
--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
@@ -3,6 +3,7 @@ package com.googlecode.cppcheclipse.ui;
 import java.io.File;
 import java.net.URI;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -36,11 +37,12 @@ import com.googlecode.cppcheclipse.core.Symbol;
  * 
  */
 public class ToolchainSettings implements IToolchainSettings {
-	private static final String EXTENSION_CPP = "cpp";
 	private final List<ICLanguageSetting> languageSettings;
 	private final ICConfigurationDescription activeConfiguration;
 	private final IProject project;
 	private final IWorkspaceRoot root;
+	private static final String GCC_LANGUAGE_ID = "org.eclipse.cdt.core.gcc";
+	private static final String GPP_LANGUAGE_ID = "org.eclipse.cdt.core.g++";
 
 	public ToolchainSettings(IProject project) throws IllegalStateException {
 		languageSettings = new LinkedList<ICLanguageSetting>();
@@ -67,13 +69,10 @@ public class ToolchainSettings implements IToolchainSettings {
 		ICLanguageSetting[] allLanguageSettings = folderDescription
 				.getLanguageSettings();
 
-		// fetch the include settings from the first tool which supports c
-		for (ICLanguageSetting languageSetting : allLanguageSettings) {
-			String extensions[] = languageSetting.getSourceExtensions();
-			for (String extension : extensions) {
-				if (EXTENSION_CPP.equalsIgnoreCase(extension)) { //$NON-NLS-1$
-					languageSettings.add(languageSetting);
-				}
+		for (ICLanguageSetting ls : allLanguageSettings) {
+			String id = ls.getLanguageId();
+			if (GCC_LANGUAGE_ID.equals(id) || GPP_LANGUAGE_ID.equals(id)) {
+			    languageSettings.add(ls);
 			}
 		}
 
@@ -161,7 +160,7 @@ public class ToolchainSettings implements IToolchainSettings {
 	 * @return all include folders in a list
 	 */
 	protected Collection<File> getIncludes(boolean onlyUserDefined) {
-		Collection<File> paths = new LinkedList<File>();
+		Collection<File> paths = new LinkedHashSet<File>();
 		IWorkspaceRoot workspaceRoot = project.getWorkspace().getRoot();
 		URI workspaceUri = workspaceRoot.getLocationURI();
 

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
@@ -41,9 +41,9 @@ public class ToolchainSettings implements IToolchainSettings {
 	private final ICConfigurationDescription activeConfiguration;
 	private final IProject project;
 	private final IWorkspaceRoot root;
-	private static final String[] C_EXTENSIONS = { "c" };
+	private static final String[] C_EXTENSIONS = { ".c", ".cl" };
 	private static final String[] CPP_EXTENSIONS = {
-			"cpp", "cxx", "cc", "c++", "ccm", "cxxm", "c++m"
+			".cpp", ".cxx", ".cc", ".c++", ".tpp", ".txx", ".ipp", ".ixx"
 	};
 
 	public ToolchainSettings(IProject project) throws IllegalStateException {

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
@@ -41,8 +41,10 @@ public class ToolchainSettings implements IToolchainSettings {
 	private final ICConfigurationDescription activeConfiguration;
 	private final IProject project;
 	private final IWorkspaceRoot root;
-	private static final String GCC_LANGUAGE_ID = "org.eclipse.cdt.core.gcc";
-	private static final String GPP_LANGUAGE_ID = "org.eclipse.cdt.core.g++";
+	private static final String[] C_EXTENSIONS = { "c" };
+	private static final String[] CPP_EXTENSIONS = {
+			"cpp", "cxx", "cc", "c++", "ccm", "cxxm", "c++m"
+	};
 
 	public ToolchainSettings(IProject project) throws IllegalStateException {
 		languageSettings = new LinkedList<ICLanguageSetting>();
@@ -70,9 +72,13 @@ public class ToolchainSettings implements IToolchainSettings {
 				.getLanguageSettings();
 
 		for (ICLanguageSetting ls : allLanguageSettings) {
-			String id = ls.getLanguageId();
-			if (GCC_LANGUAGE_ID.equals(id) || GPP_LANGUAGE_ID.equals(id)) {
-			    languageSettings.add(ls);
+			String[] exts = ls.getSourceExtensions();
+			for (String ext : exts) {
+			    if (containsIgnoreCase(C_EXTENSIONS, ext)
+			            || containsIgnoreCase(CPP_EXTENSIONS, ext)) {
+			        languageSettings.add(ls);
+			        break;
+			    }
 			}
 		}
 
@@ -236,5 +242,23 @@ public class ToolchainSettings implements IToolchainSettings {
 			}
 		}
 		return symbols;
+	}
+	
+	/**
+	 * Helper function to check if array of strings contain a given string, ignoring case.
+	 * 
+	 * @param values
+	 *            Array of strings to check
+	 * @param value
+	 *            String to check against
+	 * @return whether values contains value (ignoring case)
+	 */
+	private static boolean containsIgnoreCase(String[] values, String value) {
+	    for (String s : values) {
+	        if (s.equalsIgnoreCase(value)) {
+	            return true;
+	        }
+	    }
+	    return false;
 	}
 }


### PR DESCRIPTION
Addressing: https://github.com/cppchecksolutions/cppcheclipse/issues/11

The plugin already scans language settings for includes, but previously it only read in settings for c++ projects, i.e. include paths configured for c projects were ignored. This is now fixed.